### PR TITLE
[Fix/#26] 프로젝트 글 생성 시 사용 언어 배열로 저장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.1.4'
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.1'
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     // com.sun.xml.bind
     implementation 'com.sun.xml.bind:jaxb-impl:4.0.1'

--- a/src/main/java/com/codevumc/codev_backend/controller/co_project/CoProjectController.java
+++ b/src/main/java/com/codevumc/codev_backend/controller/co_project/CoProjectController.java
@@ -47,15 +47,12 @@ public class CoProjectController extends JwtController {
                 .co_location(project.get("co_location"))
                 .co_content(project.get("co_content"))
                 .co_deadLine(project.get("co_deadLine")).build();
-
         JSONParser parser = new JSONParser();
         Object coPartsObj = parser.parse(String.valueOf(project.get("co_parts")));
         JSONArray co_parts = (JSONArray) coPartsObj;
         Object coLanguagesObj = parser.parse(String.valueOf(project.get("co_languages")));
         JSONArray co_Languages = (JSONArray) coLanguagesObj;
-
         this.coProjectService.insertProject(coProject, co_Languages, co_parts);
-
         if(files != null) {
             List<CoPhotos> coPhotos = Arrays.asList(files)
                     .stream()

--- a/src/main/java/com/codevumc/codev_backend/controller/co_project/CoProjectController.java
+++ b/src/main/java/com/codevumc/codev_backend/controller/co_project/CoProjectController.java
@@ -63,8 +63,6 @@ public class CoProjectController extends JwtController {
             //TO-DO
             //이미지 첨부 안했을 시 랜덤으로 사진 넣기
         }
-
-
         return null;
     }
 

--- a/src/main/java/com/codevumc/codev_backend/controller/co_project/CoProjectController.java
+++ b/src/main/java/com/codevumc/codev_backend/controller/co_project/CoProjectController.java
@@ -8,6 +8,7 @@ import com.codevumc.codev_backend.jwt.JwtTokenProvider;
 import com.codevumc.codev_backend.service.co_file.CoFileServiceImpl;
 import com.codevumc.codev_backend.service.co_project.CoProjectServiceImpl;
 import com.codevumc.codev_backend.service.co_user.JwtService;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.json.simple.JSONArray;
 import org.json.simple.parser.JSONParser;
 import org.springframework.http.MediaType;
@@ -48,9 +49,12 @@ public class CoProjectController extends JwtController {
                 .co_deadLine(project.get("co_deadLine")).build();
 
         JSONParser parser = new JSONParser();
-        Object obj = parser.parse(String.valueOf(project.get("co_parts")));
-        JSONArray co_parts = (JSONArray) obj;
-        this.coProjectService.insertProject(coProject, Long.parseLong(project.get("co_languageId")), co_parts);
+        Object coPartsObj = parser.parse(String.valueOf(project.get("co_parts")));
+        JSONArray co_parts = (JSONArray) coPartsObj;
+        Object coLanguagesObj = parser.parse(String.valueOf(project.get("co_languages")));
+        JSONArray co_Languages = (JSONArray) coLanguagesObj;
+
+        this.coProjectService.insertProject(coProject, co_Languages, co_parts);
 
         if(files != null) {
             List<CoPhotos> coPhotos = Arrays.asList(files)

--- a/src/main/java/com/codevumc/codev_backend/service/co_project/CoProjectService.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_project/CoProjectService.java
@@ -1,5 +1,11 @@
 package com.codevumc.codev_backend.service.co_project;
 
-public interface CoProjectService {
+import com.codevumc.codev_backend.domain.CoProject;
+import com.codevumc.codev_backend.errorhandler.CoDevResponse;
+import org.json.simple.JSONArray;
 
+public interface CoProjectService {
+    void insertProject(CoProject coProject, JSONArray co_languages, JSONArray co_parts);
+
+    CoDevResponse getCoProject(CoProject coProject);
 }

--- a/src/main/java/com/codevumc/codev_backend/service/co_project/CoProjectServiceImpl.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_project/CoProjectServiceImpl.java
@@ -5,6 +5,7 @@ import com.codevumc.codev_backend.errorhandler.CoDevResponse;
 import com.codevumc.codev_backend.mapper.CoProjectMapper;
 import com.codevumc.codev_backend.service.ResponseService;
 import lombok.AllArgsConstructor;
+import org.json.JSONString;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.ParseException;
@@ -18,10 +19,9 @@ public class CoProjectServiceImpl extends ResponseService implements CoProjectSe
 
     public void insertProject(CoProject coProject, JSONArray co_languages, JSONArray co_parts) throws ParseException {
         this.coProjectMapper.insertCoProject(coProject);
-        //this.coProjectMapper.insertCoLanguageOfProject(coProject.getCo_projectId(), co_languageId);
         JSONObject jsonObj;
         for (Object co_language : co_languages) {
-            long co_languageId = Integer.parseInt(co_language.toString());
+            long co_languageId = (long) co_language;
             this.coProjectMapper.insertCoLanguageOfProject(coProject.getCo_projectId(), co_languageId);
         }
         for (Object co_part : co_parts) {

--- a/src/main/java/com/codevumc/codev_backend/service/co_project/CoProjectServiceImpl.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_project/CoProjectServiceImpl.java
@@ -17,7 +17,8 @@ import org.springframework.stereotype.Service;
 public class CoProjectServiceImpl extends ResponseService implements CoProjectService {
     private final CoProjectMapper coProjectMapper;
 
-    public void insertProject(CoProject coProject, JSONArray co_languages, JSONArray co_parts) throws ParseException {
+    @Override
+    public void insertProject(CoProject coProject, JSONArray co_languages, JSONArray co_parts) {
         this.coProjectMapper.insertCoProject(coProject);
         JSONObject jsonObj;
         for (Object co_language : co_languages) {
@@ -38,6 +39,7 @@ public class CoProjectServiceImpl extends ResponseService implements CoProjectSe
 //        return null;
 //    }
 
+    @Override
     public CoDevResponse getCoProject(CoProject coProject) {
         try {
             return setResponse(200, "Complete", coProject);

--- a/src/main/java/com/codevumc/codev_backend/service/co_project/CoProjectServiceImpl.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_project/CoProjectServiceImpl.java
@@ -16,16 +16,18 @@ import org.springframework.stereotype.Service;
 public class CoProjectServiceImpl extends ResponseService implements CoProjectService {
     private final CoProjectMapper coProjectMapper;
 
-    public void insertProject(CoProject coProject, long co_languageId, JSONArray co_parts) throws ParseException {
+    public void insertProject(CoProject coProject, JSONArray co_languages, JSONArray co_parts) throws ParseException {
         this.coProjectMapper.insertCoProject(coProject);
         //this.coProjectMapper.insertCoLanguageOfProject(coProject.getCo_projectId(), co_languageId);
         JSONObject jsonObj;
+        for (Object co_language : co_languages) {
+            long co_languageId = Integer.parseInt(co_language.toString());
+            this.coProjectMapper.insertCoLanguageOfProject(coProject.getCo_projectId(), co_languageId);
+        }
         for (Object co_part : co_parts) {
             jsonObj = (JSONObject) co_part;
             this.coProjectMapper.insertCoPartOfProject(coProject.getCo_projectId(), Long.parseLong(jsonObj.get("co_partId").toString()), Long.parseLong(jsonObj.get("co_limit").toString()));
         }
-
-
     }
 
 //    public CoProject getCoProject(long co_projectId) {

--- a/src/test/java/com/codevumc/codev_backend/service/co_project/CoProjectServiceTest.java
+++ b/src/test/java/com/codevumc/codev_backend/service/co_project/CoProjectServiceTest.java
@@ -1,0 +1,20 @@
+package com.codevumc.codev_backend.service.co_project;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+public class CoProjectServiceTest {
+
+    @Autowired
+    private CoProjectService coProjectService;
+
+    @Test
+    @DisplayName("프로젝트 글 작성 및 조회 테스트")
+    void CREATE_AND_READ_PROJECT() {
+
+    }
+
+
+}


### PR DESCRIPTION
### PR 타이틀 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 --> 
- #26 
### PR 날짜 🗓️
<!-- YYYY/NN/DD -->
- 2023/01/15

### 변경 사항 ❓
<!-- 내용을 적어주세요 -->
1. 사용하는 언어를 배열로 전달받아 JSONArray로 변환 후 Service로 전달
<img width="587" alt="스크린샷 2023-01-15 오후 4 58 02" src="https://user-images.githubusercontent.com/48800281/212529321-2fb71a2f-5470-4a62-9a3d-aee2c4cc4751.png">

2. Service에서 반복문 실행하며 데이터 삽입
<img width="803" alt="스크린샷 2023-01-15 오후 4 59 21" src="https://user-images.githubusercontent.com/48800281/212529363-fa35995d-a35e-4c2e-b595-24d98f048ab0.png">

### 구현 방법 🧐
<!-- 내용을 적어주세요 -->
- JSONParser를 사용하여 문자열 배열을 배열로 반환

### API 명세서 사진 📸
<!-- 사진 첨부 -->
- 현재 null을 반환

<img width="1392" alt="스크린샷 2023-01-15 오후 4 55 32" src="https://user-images.githubusercontent.com/48800281/212529500-a0257ee2-89e9-4313-a95b-f3869f39c9bd.png">

