### PR TITLE
[Fix/#50] 프로젝트 글 상세조회 시 사진 조회 추가

### DIFF
--- a/src/main/java/com/codevumc/codev_backend/controller/co_project/CoProjectController.java
+++ b/src/main/java/com/codevumc/codev_backend/controller/co_project/CoProjectController.java
@@ -50,7 +50,6 @@ public class CoProjectController extends JwtController {
 
     @PostMapping(value = "/p1/write", consumes = { MediaType.ALL_VALUE, MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_OCTET_STREAM_VALUE})
     public CoDevResponse write(HttpServletRequest request, @RequestPart Map<String, Object> project, @RequestPart(required = false) MultipartFile[] files) throws Exception {
-
         CoProject coProject = CoProject.builder()
                 .co_email(getCoUserEmail(request))
                 .co_title(project.get("co_title").toString())

--- a/src/main/java/com/codevumc/codev_backend/service/co_project/CoProjectService.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_project/CoProjectService.java
@@ -7,4 +7,6 @@ import org.json.simple.JSONArray;
 public interface CoProjectService {
     void insertProject(CoProject coProject, JSONArray co_languages, JSONArray co_parts);
     CoDevResponse getCoProject(long co_projectIc);
+    void updateMainImg(String co_mainImg, long co_projectId);
+    CoDevResponse getCoProjects(String co_email, String co_locationTag, String co_partTag, String co_keyword, String co_processTag);
 }

--- a/src/main/java/com/codevumc/codev_backend/service/co_project/CoProjectServiceImpl.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_project/CoProjectServiceImpl.java
@@ -43,10 +43,12 @@ public class CoProjectServiceImpl extends ResponseService implements CoProjectSe
         }
     }
 
+    @Override
     public void updateMainImg(String co_mainImg, long co_projectId) {
         coProjectMapper.updateCoMainImg(co_mainImg, co_projectId);
     }
 
+    @Override
     public CoDevResponse getCoProjects(String co_email, String co_locationTag, String co_partTag, String co_keyword, String co_processTag) {
         Map<String, Object> condition = new HashMap<>();
         condition.put("co_email", co_email);

--- a/src/main/java/com/codevumc/codev_backend/service/co_project/CoProjectServiceImpl.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_project/CoProjectServiceImpl.java
@@ -1,7 +1,9 @@
 package com.codevumc.codev_backend.service.co_project;
 
+import com.codevumc.codev_backend.domain.CoPhotos;
 import com.codevumc.codev_backend.domain.CoProject;
 import com.codevumc.codev_backend.errorhandler.CoDevResponse;
+import com.codevumc.codev_backend.mapper.CoPhotosMapper;
 import com.codevumc.codev_backend.mapper.CoProjectMapper;
 import com.codevumc.codev_backend.service.ResponseService;
 import lombok.AllArgsConstructor;
@@ -21,6 +23,7 @@ import java.util.Optional;
 @Service
 public class CoProjectServiceImpl extends ResponseService implements CoProjectService {
     private final CoProjectMapper coProjectMapper;
+    private final CoPhotosMapper coPhotosMapper;
 
     @Override
     public void insertProject(CoProject coProject, JSONArray co_languages, JSONArray co_parts) {
@@ -68,6 +71,7 @@ public class CoProjectServiceImpl extends ResponseService implements CoProjectSe
                 coProject.get().setCo_partList(coProjectMapper.getCoPartList(co_projectId));
                 coProject.get().setCo_languageList(coProjectMapper.getCoLanguageList(co_projectId));
                 coProject.get().setCo_heartCount(coProjectMapper.getCoHeartCount(co_projectId));
+                coProject.get().setCo_photos(coPhotosMapper.findByCoProjectId(co_projectId));
             }
                 return setResponse(200, "Complete", coProject);
         } catch (Exception e) {

--- a/src/main/resources/com/codevumc/codev_backend/mapper/CoPhotosMapper.xml
+++ b/src/main/resources/com/codevumc/codev_backend/mapper/CoPhotosMapper.xml
@@ -18,6 +18,7 @@
 
     <select id="findByCoProjectId" resultType="CoPhotos">
         select
+            co_photoId,
             co_targetId,
             co_type,
             co_uuId,
@@ -27,7 +28,7 @@
             co_fileDownloadPath,
             co_fileSize
         from CoPhotos
-        where co_targetId = #{co_projectId}
+        where co_targetId = #{co_projectId} and co_type = 'PROJECT'
     </select>
 
     <select id="findByCo_uuId" resultType="CoPhotos">


### PR DESCRIPTION
### PR 타이틀 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 --> 
- #50 
### PR 날짜 🗓️
<!-- YYYY/NN/DD -->
- 2023/1/17

### 변경 사항 ❓
<!-- 내용을 적어주세요 -->
- 조회 시 사진 조회 쿼리 동작하도록 코드 수정
```java
    @Override
    public CoDevResponse getCoProject(long co_projectId) {
        try {
            Optional<CoProject> coProject = coProjectMapper.getCoProject(co_projectId);
            if(coProject.isPresent()) {
                coProject.get().setCo_partList(coProjectMapper.getCoPartList(co_projectId));
                coProject.get().setCo_languageList(coProjectMapper.getCoLanguageList(co_projectId));
                coProject.get().setCo_heartCount(coProjectMapper.getCoHeartCount(co_projectId));
                coProject.get().setCo_photos(coPhotosMapper.findByCoProjectId(co_projectId));
            }
                return setResponse(200, "Complete", coProject);
        } catch (Exception e) {
            e.printStackTrace();
        }
        return null;
    }
```

### 구현 방법 🧐
<!-- 내용을 적어주세요 -->
- 사진 DTO를 도메인의 배열에 저장하여 반환

### API 명세서 사진 📸
<!-- 사진 첨부 -->
- 기존 조회 request와 동일
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/48800281/212824020-3952aff5-0352-4fee-8252-c898a55f4b7f.png">

