### PR TITLE
[fix/#129] 프로젝트, 스터디 조회시 자신의 이메일 조회

### DIFF
--- a/src/main/java/com/codevumc/codev_backend/controller/co_project/CoProjectController.java
+++ b/src/main/java/com/codevumc/codev_backend/controller/co_project/CoProjectController.java
@@ -39,8 +39,9 @@ public class CoProjectController extends JwtController {
     }
 
     @GetMapping("/{coProjectId}")
-    public CoDevResponse getProject(HttpServletRequest request, @PathVariable("coProjectId") long co_projectId){
-        return coProjectService.getCoProject(co_projectId);
+    public CoDevResponse getProject(HttpServletRequest request, @PathVariable("coProjectId") long co_projectId) throws Exception {
+        String co_viewer = getCoUserEmail(request);
+        return coProjectService.getCoProject(co_viewer,co_projectId);
     }
 
     @PostMapping(consumes = {MediaType.ALL_VALUE, MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_OCTET_STREAM_VALUE})

--- a/src/main/java/com/codevumc/codev_backend/controller/co_study/CoStudyController.java
+++ b/src/main/java/com/codevumc/codev_backend/controller/co_study/CoStudyController.java
@@ -82,7 +82,8 @@ public class CoStudyController extends JwtController {
 
     @GetMapping("/{coStudyId}")
     public CoDevResponse getCoStudy(HttpServletRequest request, @PathVariable("coStudyId") long coStudyId) throws Exception {
-        return coStudyService.getCoStudy(coStudyId);
+        String co_viewer = getCoUserEmail(request);
+        return coStudyService.getCoStudy(co_viewer, coStudyId);
     }
 
     @DeleteMapping("/{coStudyId}")

--- a/src/main/java/com/codevumc/codev_backend/domain/CoProject.java
+++ b/src/main/java/com/codevumc/codev_backend/domain/CoProject.java
@@ -14,6 +14,7 @@ import java.util.List;
 public class CoProject {
     private long co_projectId;
     private String co_email;
+    private String co_viewer;
     private String co_title;
     private String co_location;
     private String co_content;
@@ -28,6 +29,7 @@ public class CoProject {
     private boolean co_heart;
     private String co_parts;
     private String co_languages;
+    private boolean co_recruitStatus;
     private List<CoPhotos> co_photos;
     private List<CoPart> co_partList;
     private List<CoLanguage> co_languageList;

--- a/src/main/java/com/codevumc/codev_backend/domain/CoStudy.java
+++ b/src/main/java/com/codevumc/codev_backend/domain/CoStudy.java
@@ -14,6 +14,7 @@ import java.util.List;
 public class CoStudy {
     private long co_studyId;
     private String co_email;
+    private String co_viewer;
     private String co_title;
     private String co_location;
     private String co_content;
@@ -28,6 +29,7 @@ public class CoStudy {
     private String co_part;
     private int co_total;
     private String co_languages;
+    private boolean co_recruitStatus;
     private List<CoPhotos> co_photos;
     private List<CoLanguage> co_languageList;
 

--- a/src/main/java/com/codevumc/codev_backend/service/co_project/CoProjectService.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_project/CoProjectService.java
@@ -6,7 +6,7 @@ import org.json.simple.JSONArray;
 
 public interface CoProjectService {
     CoDevResponse insertProject(CoProject coProject, JSONArray co_languages, JSONArray co_parts);
-    CoDevResponse getCoProject(long co_projectId);
+    CoDevResponse getCoProject(String co_viewer, long co_projectId);
     void updateMainImg(String co_mainImg, long co_projectId);
     CoDevResponse getCoProjects(String co_email, String co_locationTag, String co_partTag, String co_keyword, String co_processTag, int limit, int offset, int page);
     CoDevResponse deleteCoProject(String co_email, long co_projectId);

--- a/src/main/java/com/codevumc/codev_backend/service/co_project/CoProjectServiceImpl.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_project/CoProjectServiceImpl.java
@@ -83,13 +83,14 @@ public class CoProjectServiceImpl extends ResponseService implements CoProjectSe
     }
 
     @Override
-    public CoDevResponse getCoProject(long co_projectId) {
+    public CoDevResponse getCoProject(String co_viewer, long co_projectId) {
         try {
             Optional<CoProject> coProject = coProjectMapper.getCoProject(co_projectId);
             if(coProject.isPresent()) {
                 coProject.get().setCo_partList(coProjectMapper.getCoPartList(co_projectId));
                 coProject.get().setCo_languageList(coProjectMapper.getCoLanguageList(co_projectId));
                 coProject.get().setCo_heartCount(coProjectMapper.getCoHeartCount(co_projectId));
+                coProject.get().setCo_viewer(co_viewer);
                 coProject.get().setCo_photos(coPhotosMapper.findByCoTargetId(String.valueOf(co_projectId), "PROJECT"));
             }
                 return setResponse(200, "Complete", coProject);

--- a/src/main/java/com/codevumc/codev_backend/service/co_study/CoStudyService.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_study/CoStudyService.java
@@ -7,7 +7,7 @@ import org.json.simple.JSONArray;
 public interface CoStudyService {
     CoDevResponse insertStudy(CoStudy coStudy, JSONArray co_languages);
     void updateMainImg(String co_mainImg, long co_studyId);
-    CoDevResponse getCoStudy(long co_studyId);
+    CoDevResponse getCoStudy(String co_viewer, long co_studyId);
     CoDevResponse getCoStudies(String co_email, String co_locationTag, String co_partTag, String co_keyword, String co_processTag, int limit, int offset, int page);
     CoDevResponse deleteStudy(String coUserEmail, long coStudyId);
 }

--- a/src/main/java/com/codevumc/codev_backend/service/co_study/CoStudyServiceImpl.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_study/CoStudyServiceImpl.java
@@ -54,12 +54,13 @@ public class CoStudyServiceImpl extends ResponseService implements CoStudyServic
     }
 
     @Override
-    public CoDevResponse getCoStudy(long co_studyId) {
+    public CoDevResponse getCoStudy(String co_viewer, long co_studyId) {
         try {
             Optional<CoStudy> coStudy = coStudyMapper.getCoStudy(co_studyId);
             if (coStudy.isPresent()) {
                 coStudy.get().setCo_languageList(coStudyMapper.getCoLanguageList(co_studyId));
                 coStudy.get().setCo_heartCount(coStudyMapper.getCoHeartCount(co_studyId));
+                coStudy.get().setCo_viewer(co_viewer);
                 coStudy.get().setCo_photos(coPhotosMapper.findByCoTargetId(String.valueOf(co_studyId), "STUDY"));
                 return setResponse(200, "Complete", coStudy);
             } else {


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->

### ✨ PR 타이틀 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 --> 
- #129 
### 🗓️ PR 날짜 🗓️
<!-- YYYY/NN/DD -->
- 2023/01/23

### ❓ 변경 사항 ❓
<!-- 내용을 적어주세요 -->
- co_viewer추가
프로젝트, 스터디 조회시 자신의 이메일 조회하여 게시글에 co_email과 비교하여 같으면 자신의 작성글 다르면 다른사람의 작성글

### 🧐 구현 방법 🧐
<!-- 내용을 적어주세요 -->
- 도메인에 co_viewer 추가후 컨트롤러 서비스 수정
![image](https://user-images.githubusercontent.com/88827805/214053465-85d4a115-e1b7-4d9a-835d-0f2d5c4941b8.png)


### 📸 API 명세서 사진 📸
<!-- 사진 첨부 -->
- 
![image](https://user-images.githubusercontent.com/88827805/214053585-66e16068-d2f3-44c1-b91b-80b303b0d485.png)