### PR TITLE
[Fix/#170] 작성자 지원자 판별 오류 해결

### DIFF
--- a/src/main/java/com/codevumc/codev_backend/service/co_studyrecruit/CoStudyRecruitServiceImpl.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_studyrecruit/CoStudyRecruitServiceImpl.java
@@ -32,6 +32,12 @@ public class CoStudyRecruitServiceImpl extends ResponseService implements CoStud
             } else {
                 return setResponse(446, "Fail", "지원 실패하였습니다.");
             }
+        } catch (BindingException e) {
+            try {
+                return setResponse(403, "Forbidden", "잘못된 아이디 값 입니다.");
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            }
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -51,6 +57,12 @@ public class CoStudyRecruitServiceImpl extends ResponseService implements CoStud
                 return setResponse(200, "Complete", "지원 취소되었습니다.");
             } else {
                 return setResponse(403, "Forbidden", "수정 권한이 없습니다.");
+            }
+        } catch (BindingException e) {
+            try {
+                return setResponse(403, "Forbidden", "잘못된 아이디 값 입니다.");
+            } catch (Exception ex) {
+                ex.printStackTrace();
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/com/codevumc/codev_backend/service/co_studyrecruit/CoStudyRecruitServiceImpl.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_studyrecruit/CoStudyRecruitServiceImpl.java
@@ -6,6 +6,7 @@ import com.codevumc.codev_backend.errorhandler.CoDevResponse;
 import com.codevumc.codev_backend.mapper.CoStudyMapper;
 import com.codevumc.codev_backend.service.ResponseService;
 import lombok.AllArgsConstructor;
+import org.apache.ibatis.binding.BindingException;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
@@ -72,6 +73,12 @@ public class CoStudyRecruitServiceImpl extends ResponseService implements CoStud
                     return setResponse(200, "Complete", applicants);
             } else {
                 return setResponse(403, "Forbidden", "권한이 없습니다.");
+            }
+        } catch (BindingException e) {
+            try {
+                return setResponse(403, "Forbidden", "잘못된 아이디 값 입니다.");
+            } catch (Exception ex) {
+                ex.printStackTrace();
             }
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->

### ✨ PR 타이틀 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 --> 
- #170 
### 🗓️ PR 날짜 🗓️
<!-- YYYY/NN/DD -->
- 2023/01/25

### ❓ 변경 사항 ❓
<!-- 내용을 적어주세요 -->
- 작성자 지원자 판별 오류처리 완료

### 🧐 구현 방법 🧐
<!-- 내용을 적어주세요 -->
isWriter의 값이 null일때 발생하는 오류를 다음과 같이 처리하여 해결함
![image](https://user-images.githubusercontent.com/76439068/214550986-6ba6e5bd-6473-4375-8f74-019bf1ae7ab4.png)

### 📸 API 명세서 사진 📸
<!-- 사진 첨부 -->
다음과 같은 에러 메시지를 출력한다.
![image](https://user-images.githubusercontent.com/76439068/214551083-b7d091b3-f422-456d-a7c1-81030acf8709.png)

