### PR TITLE
[Fix/#210] 스터디 글 수정시 CoPartOfStudy 삭제 추가

### DIFF
--- a/src/main/java/com/codevumc/codev_backend/mapper/CoStudyMapper.java
+++ b/src/main/java/com/codevumc/codev_backend/mapper/CoStudyMapper.java
@@ -19,6 +19,7 @@ public interface CoStudyMapper {
     void updateCoStudy(CoStudy coStudy);
     void insertCoLanguageOfStudy(long co_studyId, long co_languageId);
     void deleteCoLanguageOfStudy(long co_studyId);
+    void deleteCoPartOfStudy(long co_studyId);
     void updateCoMainImg(@Param("co_mainImg") String co_mainImg, @Param("co_studyId") long co_studyId);
     void insertCoPartOfStudy(Map<String, Object> coPartDto);
     Optional<CoStudy> getCoStudy(long co_studyId);

--- a/src/main/java/com/codevumc/codev_backend/service/co_study/CoStudyServiceImpl.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_study/CoStudyServiceImpl.java
@@ -53,6 +53,7 @@ public class CoStudyServiceImpl extends ResponseService implements CoStudyServic
             }
             this.coStudyMapper.updateCoStudy(coStudy);
             this.coStudyMapper.deleteCoLanguageOfStudy(coStudy.getCo_studyId());
+            this.coStudyMapper.deleteCoPartOfStudy(coStudy.getCo_studyId());
             return insertCoLanguageAndCoPart(co_languages, coStudy);
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/resources/com/codevumc/codev_backend/mapper/CoStudyMapper.xml
+++ b/src/main/resources/com/codevumc/codev_backend/mapper/CoStudyMapper.xml
@@ -125,6 +125,10 @@
         delete from CoLanguageOfStudy where co_studyId = #{co_studyId}
     </delete>
 
+    <delete id="deleteCoPartOfStudy">
+        delete from CoPartOfStudy where co_studyId = #{co_studyId}
+    </delete>
+
     <insert id="insertCoLanguageOfStudy">
         INSERT INTO CoLanguageOfStudy
             (co_studyId, co_languageId)


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->

### ✨ PR 타이틀 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 --> 
- #210 
### 🗓️ PR 날짜 🗓️
<!-- YYYY/NN/DD -->
- 2023/02/01

### ❓ 변경 사항 ❓
<!-- 내용을 적어주세요 -->
- 스터디 글 수정 시 deleteCoLanguageOfStudy처럼 CoPartOfStudy 삭제 추가 

### 🧐 구현 방법 🧐
<!-- 내용을 적어주세요 -->
- 에러 수정전 다음과 같은 에러 메시지가 발생하였다.
nested exception is org.apache.ibatis.exceptions.TooManyResultsException: Expected one result (or null) to be returned by selectOne(), but found: 2
이를 통해 결과값이 두개가 나온다는 것을 알 수 있었고, 원인 파악 결과 CoPartOfStudy에서 데이터를 삭제되지 않고 삽입만 되고 있는 것을 볼 수 있었다. 따라서 삭제 메서드를 생성하고 이를 해결하였다.
- serviceImpl
![image](https://user-images.githubusercontent.com/76439068/215935212-9325ce93-af69-43b6-ab40-9dc2f2128ea4.png)

- mapper.xml
![image](https://user-images.githubusercontent.com/76439068/215935267-1fe38af9-aa80-43ce-a48e-d115028ebfaf.png)

### 📸 API 명세서 사진 📸
<!-- 사진 첨부 -->
![image](https://user-images.githubusercontent.com/76439068/215935546-8872712c-9cad-4359-9a05-7502b521bdb8.png)

![image](https://user-images.githubusercontent.com/76439068/215935774-c02e696b-fb2c-4d9b-beb0-3e69cca43eba.png)

