### PR TITLE
[Fix/#217] 스터디 상세조회 쿼리 수정

### DIFF
--- a/src/main/java/com/codevumc/codev_backend/domain/CoStudy.java
+++ b/src/main/java/com/codevumc/codev_backend/domain/CoStudy.java
@@ -14,6 +14,7 @@ import java.util.List;
 public class CoStudy {
     private long co_studyId;
     private String co_email;
+    private String co_nickName;
     private String co_viewer;
     private String co_title;
     private String co_location;

--- a/src/main/java/com/codevumc/codev_backend/mapper/CoStudyMapper.java
+++ b/src/main/java/com/codevumc/codev_backend/mapper/CoStudyMapper.java
@@ -38,4 +38,6 @@ public interface CoStudyMapper {
     void updateCoStudyDeadLine(CoStudy coStudy);
     void updateCoStudyMemberApprove(String co_email, long co_studyId);
     void completeCoStudyRecruitment(Map<String, Object> condition);
+    boolean getCoHeartOfStudyCheck(String co_viewer, long co_studyId);
+    String getCoUserNickName(@Param("co_email") String co_email);
 }

--- a/src/main/java/com/codevumc/codev_backend/mapper/CoStudyMapper.java
+++ b/src/main/java/com/codevumc/codev_backend/mapper/CoStudyMapper.java
@@ -38,6 +38,6 @@ public interface CoStudyMapper {
     void updateCoStudyDeadLine(CoStudy coStudy);
     void updateCoStudyMemberApprove(String co_email, long co_studyId);
     void completeCoStudyRecruitment(Map<String, Object> condition);
-    boolean getCoHeartOfStudyCheck(String co_viewer, long co_studyId);
+    Optional<Boolean> getCoHeartOfStudyCheck(String co_viewer, long co_studyId);
     String getCoUserNickName(@Param("co_email") String co_email);
 }

--- a/src/main/java/com/codevumc/codev_backend/service/co_study/CoStudyServiceImpl.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_study/CoStudyServiceImpl.java
@@ -67,10 +67,12 @@ public class CoStudyServiceImpl extends ResponseService implements CoStudyServic
             Optional<CoStudy> coStudy = coStudyMapper.getCoStudy(co_studyId);
             if (coStudy.isPresent()) {
                 coStudy.get().setCo_viewer(co_viewer);
+                coStudy.get().setCo_email(coStudyMapper.getCoUserNickName(coStudy.get().getCo_email()));
                 coStudy.get().setCo_recruitStatus(coStudyMapper.getCoRecruitStatus(co_viewer, co_studyId));
                 coStudy.get().setCo_languageList(coStudyMapper.getCoLanguageList(co_studyId));
                 coStudy.get().setCo_heartCount(coStudyMapper.getCoHeartCount(co_studyId));
                 coStudy.get().setCo_photos(coPhotosMapper.findByCoTargetId(String.valueOf(co_studyId), "STUDY"));
+                coStudy.get().setCo_heart(coStudyMapper.getCoHeartOfStudyCheck(co_viewer,co_studyId));
                 return setResponse(200, "Complete", coStudy);
             } else {
                 return setResponse(403, "Forbidden", "불러오기 실패하였습니다.");

--- a/src/main/java/com/codevumc/codev_backend/service/co_study/CoStudyServiceImpl.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_study/CoStudyServiceImpl.java
@@ -72,7 +72,11 @@ public class CoStudyServiceImpl extends ResponseService implements CoStudyServic
                 coStudy.get().setCo_languageList(coStudyMapper.getCoLanguageList(co_studyId));
                 coStudy.get().setCo_heartCount(coStudyMapper.getCoHeartCount(co_studyId));
                 coStudy.get().setCo_photos(coPhotosMapper.findByCoTargetId(String.valueOf(co_studyId), "STUDY"));
-                coStudy.get().setCo_heart(coStudyMapper.getCoHeartOfStudyCheck(co_viewer,co_studyId));
+                if(coStudyMapper.getCoHeartOfStudyCheck(co_viewer,co_studyId).isEmpty()){
+                    coStudy.get().setCo_heart(false);
+                }else{
+                    coStudy.get().setCo_heart(true);
+                }
                 return setResponse(200, "Complete", coStudy);
             } else {
                 return setResponse(403, "Forbidden", "불러오기 실패하였습니다.");

--- a/src/main/java/com/codevumc/codev_backend/service/co_study/CoStudyServiceImpl.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_study/CoStudyServiceImpl.java
@@ -67,7 +67,7 @@ public class CoStudyServiceImpl extends ResponseService implements CoStudyServic
             Optional<CoStudy> coStudy = coStudyMapper.getCoStudy(co_studyId);
             if (coStudy.isPresent()) {
                 coStudy.get().setCo_viewer(co_viewer);
-                coStudy.get().setCo_email(coStudyMapper.getCoUserNickName(coStudy.get().getCo_email()));
+                coStudy.get().setCo_nickName(coStudyMapper.getCoUserNickName(coStudy.get().getCo_email()));
                 coStudy.get().setCo_recruitStatus(coStudyMapper.getCoRecruitStatus(co_viewer, co_studyId));
                 coStudy.get().setCo_languageList(coStudyMapper.getCoLanguageList(co_studyId));
                 coStudy.get().setCo_heartCount(coStudyMapper.getCoHeartCount(co_studyId));

--- a/src/main/resources/com/codevumc/codev_backend/mapper/CoStudyMapper.xml
+++ b/src/main/resources/com/codevumc/codev_backend/mapper/CoStudyMapper.xml
@@ -63,6 +63,8 @@
         select
             cs.co_studyId as co_studyId,
             cs.co_email as co_email,
+            cu.co_nickName as co_nickName,
+            if (chos.status, true, false) as co_heart,
             cs.co_title as co_title,
             cs.co_location as co_location,
             cs.co_content as co_content,
@@ -76,6 +78,8 @@
             cs.status as status
         from CoStudy cs
                  left join CoPartOfStudy cpos on cs.co_studyId = cpos.co_studyId
+                 left join CoUser cu on cs.co_email = cu.co_email
+                 left join CoHeartOfStudy chos on cs.co_studyId = chos.co_studyId and chos.co_email = #{co_email}
         where cs.co_studyId = #{co_studyId}
     </select>
 

--- a/src/main/resources/com/codevumc/codev_backend/mapper/CoStudyMapper.xml
+++ b/src/main/resources/com/codevumc/codev_backend/mapper/CoStudyMapper.xml
@@ -75,10 +75,23 @@
             cs.updatedAt as updatedAt,
             cs.status as status
         from CoStudy cs
-        left join CoPartOfStudy cpos on cs.co_studyId = cpos.co_studyId
+                 left join CoPartOfStudy cpos on cs.co_studyId = cpos.co_studyId
         where cs.co_studyId = #{co_studyId}
     </select>
 
+    <select id ="getCoHeartOfStudyCheck"  resultType="boolean">
+        select
+        chs.status as co_heart
+        from CoHeartOfStudy as chs
+        where chs.co_studyId = #{co_studyId} and chs.co_email = #{co_viewer}
+    </select>
+
+    <select id ="getCoUserNickName" parameterType="String" resultType="String">
+        select
+        cu.co_nickName
+        from CoUser as cu
+        where cu.co_email = #{co_email}
+    </select>
     <select id="getCoLanguageList" resultType="CoLanguageOfStudy">
         select cl.co_languageId, cl.co_language, cl.co_logo
         from CoLanguageOfStudy cop


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->

### ✨ PR 타이틀 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 --> 
-  #217 
### 🗓️ PR 날짜 🗓️
<!-- YYYY/NN/DD -->
-  2023/02/02

### ❓ 변경 사항 ❓
<!-- 내용을 적어주세요 -->
-  CoStudyServiceImpl
<img width="806" alt="image" src="https://user-images.githubusercontent.com/79689822/216116318-f049caf7-b0ac-4b79-a6ea-78f04a7a130b.png">

- CoStudy에 nickname은 따로 없어서 nickname을 도메인에 추가
- 찜 여부 확인 쿼리, 닉네임 가져오는 쿼리는 email이 필요해서 기존의 getCoStudy 쿼리를 이용할 수 없었음 여러 쿼리로 분할


### 🧐 구현 방법 🧐
<!-- 내용을 적어주세요 -->
<img width="513" alt="image" src="https://user-images.githubusercontent.com/79689822/216117226-60d6b5b0-8bbb-48eb-a5b8-af37f35035c1.png">

쿼리 각각 작성함

### 📸 API 명세서 사진 📸
<!-- 사진 첨부 -->
<img width="469" alt="image" src="https://user-images.githubusercontent.com/79689822/216117374-47d3273b-55b6-4584-b5ca-47ff93fab164.png">

닉네임 (닉네임값에 담김)
찜여부 (co_heart 에 담김)
*확인요망