### PR TITLE
[Feat/#232] 프로젝트 지원자 임시저장/취소

### DIFF
--- a/src/main/java/com/codevumc/codev_backend/controller/co_project/CoProjectController.java
+++ b/src/main/java/com/codevumc/codev_backend/controller/co_project/CoProjectController.java
@@ -161,14 +161,13 @@ public class CoProjectController extends JwtController {
 
     @PatchMapping("/recruitment/pick/{coProjectId}")
     public CoDevResponse saveCoApplicantsTemporarily(HttpServletRequest request,
-                                                     @PathVariable("co_projectId") long co_projectId,
+                                                     @PathVariable("coProjectId") long co_projectId,
                                                      @RequestBody CoTempSaveApplicants coTempSaveApplicants) throws Exception {
         String co_eamil = getCoUserEmail(request);
         for (String s : coTempSaveApplicants.getCo_emails()) {
             System.out.println(s);
         }
-        coProjectRecruitService.saveCoApplicantsTemporarily(co_eamil, co_projectId, coTempSaveApplicants);
-        return null;
+        return coProjectRecruitService.saveCoApplicantsTemporarily(co_eamil, co_projectId, coTempSaveApplicants);
     }
 
 

--- a/src/main/java/com/codevumc/codev_backend/controller/co_project/CoProjectController.java
+++ b/src/main/java/com/codevumc/codev_backend/controller/co_project/CoProjectController.java
@@ -164,12 +164,8 @@ public class CoProjectController extends JwtController {
                                                      @PathVariable("coProjectId") long co_projectId,
                                                      @RequestBody CoTempSaveApplicants coTempSaveApplicants) throws Exception {
         String co_eamil = getCoUserEmail(request);
-        for (String s : coTempSaveApplicants.getCo_emails()) {
-            System.out.println(s);
-        }
         return coProjectRecruitService.saveCoApplicantsTemporarily(co_eamil, co_projectId, coTempSaveApplicants);
     }
-
 
     private int getLimitCnt(int pageNum) {
         int limit = SHOW_COUNT;

--- a/src/main/java/com/codevumc/codev_backend/controller/co_project/CoProjectController.java
+++ b/src/main/java/com/codevumc/codev_backend/controller/co_project/CoProjectController.java
@@ -4,6 +4,7 @@ import com.codevumc.codev_backend.controller.JwtController;
 import com.codevumc.codev_backend.domain.CoPhotos;
 import com.codevumc.codev_backend.domain.CoProject;
 import com.codevumc.codev_backend.domain.CoRecruitOfProject;
+import com.codevumc.codev_backend.domain.CoTempSaveApplicants;
 import com.codevumc.codev_backend.errorhandler.CoDevResponse;
 import com.codevumc.codev_backend.jwt.JwtTokenProvider;
 import com.codevumc.codev_backend.service.co_file.CoFileServiceImpl;
@@ -157,6 +158,19 @@ public class CoProjectController extends JwtController {
         String co_email = getCoUserEmail(request);
         return coProjectRecruitService.getCoPortfolioOfApplicant(co_email, co_projectId, co_portfolioId);
     }
+
+    @PatchMapping("/recruitment/pick/{coProjectId}")
+    public CoDevResponse saveCoApplicantsTemporarily(HttpServletRequest request,
+                                                     @PathVariable("co_projectId") long co_projectId,
+                                                     @RequestBody CoTempSaveApplicants coTempSaveApplicants) throws Exception {
+        String co_eamil = getCoUserEmail(request);
+        for (String s : coTempSaveApplicants.getCo_emails()) {
+            System.out.println(s);
+        }
+        coProjectRecruitService.saveCoApplicantsTemporarily(co_eamil, co_projectId, coTempSaveApplicants);
+        return null;
+    }
+
 
     private int getLimitCnt(int pageNum) {
         int limit = SHOW_COUNT;

--- a/src/main/java/com/codevumc/codev_backend/domain/CoTempSaveApplicants.java
+++ b/src/main/java/com/codevumc/codev_backend/domain/CoTempSaveApplicants.java
@@ -8,5 +8,5 @@ import java.util.List;
 @Getter
 @Setter
 public class CoTempSaveApplicants {
-    List<String> coApplicantInfos;
+    List<String> co_emails;
 }

--- a/src/main/java/com/codevumc/codev_backend/domain/CoTempSaveApplicants.java
+++ b/src/main/java/com/codevumc/codev_backend/domain/CoTempSaveApplicants.java
@@ -1,0 +1,12 @@
+package com.codevumc.codev_backend.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class CoTempSaveApplicants {
+    List<String> coApplicantInfos;
+}

--- a/src/main/java/com/codevumc/codev_backend/domain/CoTempSaveApplicants.java
+++ b/src/main/java/com/codevumc/codev_backend/domain/CoTempSaveApplicants.java
@@ -9,4 +9,14 @@ import java.util.List;
 @Setter
 public class CoTempSaveApplicants {
     List<String> co_emails;
+
+    public boolean checkAllTempSave(List<Boolean> coTempSaveStatus) {
+        for (int i = 1; i < coTempSaveStatus.size(); i++) {
+            if (coTempSaveStatus.get(i) != coTempSaveStatus.get(0)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
 }

--- a/src/main/java/com/codevumc/codev_backend/mapper/CoProjectMapper.java
+++ b/src/main/java/com/codevumc/codev_backend/mapper/CoProjectMapper.java
@@ -39,4 +39,6 @@ public interface CoProjectMapper {
     List<CoApplicantCount> getCoApplicantsCount(long co_projectId);
     Optional<CoProject> getCoProjectByViewer(Map<String, Object> coProjectDto);
     Optional<CoPortfolioOfApplicant> getCoPortfolioOfApplicant(Map<String, Object> coPortfolioDro);
+    List<Boolean> getCoTemporaryStorage(Map<String, Object> coApplicantsInfoDto);
+    boolean updateCoTemporaryStorage(List<String> coApplicantInfos);
 }

--- a/src/main/java/com/codevumc/codev_backend/mapper/CoProjectMapper.java
+++ b/src/main/java/com/codevumc/codev_backend/mapper/CoProjectMapper.java
@@ -40,5 +40,5 @@ public interface CoProjectMapper {
     Optional<CoProject> getCoProjectByViewer(Map<String, Object> coProjectDto);
     Optional<CoPortfolioOfApplicant> getCoPortfolioOfApplicant(Map<String, Object> coPortfolioDro);
     List<Boolean> getCoTemporaryStorage(Map<String, Object> coApplicantsInfoDto);
-    boolean updateCoTemporaryStorage(List<String> coApplicantInfos);
+    boolean updateCoTemporaryStorage(Map<String, Object> coApplicantsInfoDto);
 }

--- a/src/main/java/com/codevumc/codev_backend/service/co_projectrecruit/CoProjectRecruitService.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_projectrecruit/CoProjectRecruitService.java
@@ -1,11 +1,9 @@
 package com.codevumc.codev_backend.service.co_projectrecruit;
 
-import com.codevumc.codev_backend.domain.CoApplicantInfo;
 import com.codevumc.codev_backend.domain.CoProject;
 import com.codevumc.codev_backend.domain.CoRecruitOfProject;
+import com.codevumc.codev_backend.domain.CoTempSaveApplicants;
 import com.codevumc.codev_backend.errorhandler.CoDevResponse;
-
-import java.util.List;
 
 public interface CoProjectRecruitService {
     CoDevResponse insertCoRecruitOfProject(CoRecruitOfProject coRecruitOfProject);
@@ -13,5 +11,5 @@ public interface CoProjectRecruitService {
     CoDevResponse getCoApplicantsOfProject(String co_email, long co_projectId, String co_part);
     CoDevResponse closeCoProjectDeadLine(String co_email, Long co_projectId, CoProject co_applicantsList);
     CoDevResponse getCoPortfolioOfApplicant(String co_email, long co_projectId, long co_portfolioId);
-    CoDevResponse saveCoApplicantsTemporarily(String co_email, long co_projectId, List<CoApplicantInfo> coApplicantInfos);
+    CoDevResponse saveCoApplicantsTemporarily(String co_email, long co_projectId, CoTempSaveApplicants coTempSaveApplicants);
 }

--- a/src/main/java/com/codevumc/codev_backend/service/co_projectrecruit/CoProjectRecruitService.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_projectrecruit/CoProjectRecruitService.java
@@ -1,8 +1,11 @@
 package com.codevumc.codev_backend.service.co_projectrecruit;
 
+import com.codevumc.codev_backend.domain.CoApplicantInfo;
 import com.codevumc.codev_backend.domain.CoProject;
 import com.codevumc.codev_backend.domain.CoRecruitOfProject;
 import com.codevumc.codev_backend.errorhandler.CoDevResponse;
+
+import java.util.List;
 
 public interface CoProjectRecruitService {
     CoDevResponse insertCoRecruitOfProject(CoRecruitOfProject coRecruitOfProject);
@@ -10,4 +13,5 @@ public interface CoProjectRecruitService {
     CoDevResponse getCoApplicantsOfProject(String co_email, long co_projectId, String co_part);
     CoDevResponse closeCoProjectDeadLine(String co_email, Long co_projectId, CoProject co_applicantsList);
     CoDevResponse getCoPortfolioOfApplicant(String co_email, long co_projectId, long co_portfolioId);
+    CoDevResponse saveCoApplicantsTemporarily(String co_email, long co_projectId, List<CoApplicantInfo> coApplicantInfos);
 }

--- a/src/main/java/com/codevumc/codev_backend/service/co_projectrecruit/CoProjectRecruitServiceImpl.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_projectrecruit/CoProjectRecruitServiceImpl.java
@@ -145,13 +145,9 @@ public class CoProjectRecruitServiceImpl extends ResponseService implements CoPr
                 Map<String, Object> coApplicantsInfoDto = new HashMap<>();
                 coApplicantsInfoDto.put("co_emails", coTempSaveApplicants.getCo_emails());
                 coApplicantsInfoDto.put("co_projectId", co_projectId);
-
                 if (!coTempSaveApplicants.checkAllTempSave(this.coProjectMapper.getCoTemporaryStorage(coApplicantsInfoDto))) {
                     return setResponse(400, "message", "임시저장 여부가 다른 지원자가 존재합니다.");
                 }
-
-                System.out.println("조회 성공");
-
                 if (this.coProjectMapper.updateCoTemporaryStorage(coApplicantsInfoDto)) {
                     return setResponse(200, "message", "일괄 처리 되었습니다.");
                 }

--- a/src/main/java/com/codevumc/codev_backend/service/co_projectrecruit/CoProjectRecruitServiceImpl.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_projectrecruit/CoProjectRecruitServiceImpl.java
@@ -163,5 +163,4 @@ public class CoProjectRecruitServiceImpl extends ResponseService implements CoPr
         return null;
     }
 
-
 }

--- a/src/main/java/com/codevumc/codev_backend/service/co_projectrecruit/CoProjectRecruitServiceImpl.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_projectrecruit/CoProjectRecruitServiceImpl.java
@@ -153,7 +153,7 @@ public class CoProjectRecruitServiceImpl extends ResponseService implements CoPr
                        return setResponse(400, "message", "임시저장 여부가 다른 지원자가 존재합니다.");
                 }
 
-                if (this.coProjectMapper.updateCoTemporaryStorage()) {
+                if (this.coProjectMapper.updateCoTemporaryStorage(coTempSaveApplicants.getCoApplicantInfos())) {
                     return setResponse(200, "message", "일괄 처리 되었습니다.");
                 }
             }

--- a/src/main/java/com/codevumc/codev_backend/service/co_projectrecruit/CoProjectRecruitServiceImpl.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_projectrecruit/CoProjectRecruitServiceImpl.java
@@ -143,7 +143,7 @@ public class CoProjectRecruitServiceImpl extends ResponseService implements CoPr
                 if (!coProjectOptional.get().getCo_email().equals(co_email))
                     return setResponse(403, "Forbidden", "조회 권한이 없습니다.");
                 Map<String, Object> coApplicantsInfoDto = new HashMap<>();
-                coApplicantsInfoDto.put("co_tempSaveApplicants", coTempSaveApplicants.getCoApplicantInfos());
+                coApplicantsInfoDto.put("co_tempSaveApplicants", coTempSaveApplicants.getCo_emails());
                 coApplicantsInfoDto.put("co_projectId", co_projectId);
 
                 List<Boolean> coTempSaveStatus = this.coProjectMapper.getCoTemporaryStorage(coApplicantsInfoDto);
@@ -153,7 +153,7 @@ public class CoProjectRecruitServiceImpl extends ResponseService implements CoPr
                        return setResponse(400, "message", "임시저장 여부가 다른 지원자가 존재합니다.");
                 }
 
-                if (this.coProjectMapper.updateCoTemporaryStorage(coTempSaveApplicants.getCoApplicantInfos())) {
+                if (this.coProjectMapper.updateCoTemporaryStorage(coTempSaveApplicants.getCo_emails())) {
                     return setResponse(200, "message", "일괄 처리 되었습니다.");
                 }
             }

--- a/src/main/java/com/codevumc/codev_backend/service/co_projectrecruit/CoProjectRecruitServiceImpl.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_projectrecruit/CoProjectRecruitServiceImpl.java
@@ -143,17 +143,16 @@ public class CoProjectRecruitServiceImpl extends ResponseService implements CoPr
                 if (!coProjectOptional.get().getCo_email().equals(co_email))
                     return setResponse(403, "Forbidden", "조회 권한이 없습니다.");
                 Map<String, Object> coApplicantsInfoDto = new HashMap<>();
-                coApplicantsInfoDto.put("co_tempSaveApplicants", coTempSaveApplicants.getCo_emails());
+                coApplicantsInfoDto.put("co_emails", coTempSaveApplicants.getCo_emails());
                 coApplicantsInfoDto.put("co_projectId", co_projectId);
 
-                List<Boolean> coTempSaveStatus = this.coProjectMapper.getCoTemporaryStorage(coApplicantsInfoDto);
-
-                for (Boolean tempSaveStatus : coTempSaveStatus) {
-                   if(!tempSaveStatus)
-                       return setResponse(400, "message", "임시저장 여부가 다른 지원자가 존재합니다.");
+                if (!coTempSaveApplicants.checkAllTempSave(this.coProjectMapper.getCoTemporaryStorage(coApplicantsInfoDto))) {
+                    return setResponse(400, "message", "임시저장 여부가 다른 지원자가 존재합니다.");
                 }
 
-                if (this.coProjectMapper.updateCoTemporaryStorage(coTempSaveApplicants.getCo_emails())) {
+                System.out.println("조회 성공");
+
+                if (this.coProjectMapper.updateCoTemporaryStorage(coApplicantsInfoDto)) {
                     return setResponse(200, "message", "일괄 처리 되었습니다.");
                 }
             }

--- a/src/main/resources/com/codevumc/codev_backend/mapper/CoProjectMapper.xml
+++ b/src/main/resources/com/codevumc/codev_backend/mapper/CoProjectMapper.xml
@@ -288,4 +288,12 @@
         where cp.co_portfolioId = #{co_portfolioId};
     </select>
 
+    <select id="getCoTemporaryStorage" parameterType="List" resultType="Boolean">
+        select
+        from CoRecruitOfProject
+        where co_email in
+        <foreach collection="List" item="co_email" index="index" open="(" separator="or" close=")">
+            #{co_email}
+        </foreach>
+    </select>
 </mapper>

--- a/src/main/resources/com/codevumc/codev_backend/mapper/CoProjectMapper.xml
+++ b/src/main/resources/com/codevumc/codev_backend/mapper/CoProjectMapper.xml
@@ -288,12 +288,24 @@
         where cp.co_portfolioId = #{co_portfolioId};
     </select>
 
-    <select id="getCoTemporaryStorage" parameterType="List" resultType="Boolean">
+    <select id="getCoTemporaryStorage" parameterType="hashMap" resultType="Boolean">
         select
-        from CoRecruitOfProject
-        where co_email in
-        <foreach collection="List" item="co_email" index="index" open="(" separator="or" close=")">
+            crop.co_temporaryStorage
+        from CoRecruitOfProject crop
+        where crop.co_projectId = #{co_projectId}
+            and crop.co_email in
+        <foreach collection="co_emails" item="co_email" index="index" open="(" separator="," close=")">
             #{co_email}
         </foreach>
     </select>
+
+    <update id="updateCoTemporaryStorage" parameterType="hashMap">
+        update CoRecruitOfProject crop
+        set crop.co_temporaryStorage = !crop.co_temporaryStorage
+        where crop.co_projectId = #{co_projectId}
+            and crop.co_email in
+        <foreach collection="co_emails" item="co_email" index="index" open="(" separator="," close=")">
+            #{co_email}
+        </foreach>
+    </update>
 </mapper>


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->

### ✨ PR 타이틀 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 --> 
- #232 
### 🗓️ PR 날짜 🗓️
<!-- YYYY/NN/DD -->
- 2023/2/3

### ❓ 변경 사항 ❓
<!-- 내용을 적어주세요 -->
- RequestBody값으로 메일을 받기 위한 도메인 추가

### 🧐 구현 방법 🧐
<!-- 내용을 적어주세요 -->
- RequestBody값으로 메일을 받기 위한 도메인 추가
- 임시저장하려는 회원들의 임시저장여부가 동일한지 체크하는 함수를 서비스 코드에 작성하니 복잡해서 도메인에 작성
- 스터디 지원자 임시저장 기능에서도 같은 로직이 사용될 것 같아서 도메인에 뺀 이유도 있음
  - 어떤 방식이 좋을지 모르겠음 -> 피드백 부탁
```java
@Getter
@Setter
public class CoTempSaveApplicants {
    List<String> co_emails;

    public boolean checkAllTempSave(List<Boolean> coTempSaveStatus) {
        for (int i = 1; i < coTempSaveStatus.size(); i++) {
            if (coTempSaveStatus.get(i) != coTempSaveStatus.get(0)) {
                return false;
            }
        }
        return true;
    }

}
```

- service
```java
    @Override
    public CoDevResponse saveCoApplicantsTemporarily(String co_email, long co_projectId, CoTempSaveApplicants coTempSaveApplicants) {
        try {
            Optional<CoProject> coProjectOptional = this.coProjectMapper.getCoProject(co_projectId);
            if (coProjectOptional.isPresent()) {
                if (!coProjectOptional.get().getCo_email().equals(co_email))
                    return setResponse(403, "Forbidden", "조회 권한이 없습니다.");

                Map<String, Object> coApplicantsInfoDto = new HashMap<>();
                coApplicantsInfoDto.put("co_emails", coTempSaveApplicants.getCo_emails());
                coApplicantsInfoDto.put("co_projectId", co_projectId);

                if (!coTempSaveApplicants.checkAllTempSave(this.coProjectMapper.getCoTemporaryStorage(coApplicantsInfoDto))) {
                    return setResponse(400, "message", "임시저장 여부가 다른 지원자가 존재합니다.");
                }

                if (this.coProjectMapper.updateCoTemporaryStorage(coApplicantsInfoDto)) {
                    return setResponse(200, "message", "일괄 처리 되었습니다.");
                }

            }
        } catch (Exception e) {
            e.printStackTrace();
        }
        return null;
    }
```

- mapper
  - `foreach` 사용하여 반복문으로 쿼리 작성
-  요청 들어온 지원자들의 임시저장여부가 모두 동일한지 체크하는 쿼리
```sql
    <select id="getCoTemporaryStorage" parameterType="hashMap" resultType="Boolean">
        select
            crop.co_temporaryStorage
        from CoRecruitOfProject crop
        where crop.co_projectId = #{co_projectId}
            and crop.co_email in
        <foreach collection="co_emails" item="co_email" index="index" open="(" separator="," close=")">
            #{co_email}
        </foreach>
    </select>
```

- 지원자들의 임시저장 여부를 일괄적으로 반대 값으로 변경시키는 쿼리
```sql
    <update id="updateCoTemporaryStorage" parameterType="hashMap">
        update CoRecruitOfProject crop
        set crop.co_temporaryStorage = !crop.co_temporaryStorage
        where crop.co_projectId = #{co_projectId}
            and crop.co_email in
        <foreach collection="co_emails" item="co_email" index="index" open="(" separator="," close=")">
            #{co_email}
        </foreach>
    </update>
```

### 📸 API 명세서 사진 📸
<!-- 사진 첨부 -->
> URL : http://localhost:8080/codev/project/recruitment/pick/:coProjectId

- RequestBody
```json
{
    "co_emails": [
        "zxz4641@naver.com",
        "simhani1@naver.com"
    ]
}
```
<img width="1359" alt="image" src="https://user-images.githubusercontent.com/48800281/216567267-9acb7c72-2ec2-4775-8c28-e3f036014877.png">


- 임시저장/취소 정상 처리
<img width="1359" alt="image" src="https://user-images.githubusercontent.com/48800281/216566725-c5460df7-7539-4172-a9f9-ab472c38810d.png">

- 임시저장 여부가 한명이라도 다른 경우
<img width="1359" alt="image" src="https://user-images.githubusercontent.com/48800281/216566923-967906a9-e518-48fc-939c-cd6f105c7833.png">
