### PR TITLE
[fix/#244] 비밀번호 변경 에러메세지 수정

### DIFF
--- a/src/main/java/com/codevumc/codev_backend/controller/co_user/CoUserController.java
+++ b/src/main/java/com/codevumc/codev_backend/controller/co_user/CoUserController.java
@@ -114,7 +114,7 @@ public class CoUserController extends JwtController {
                 .co_email(getCoUserEmail(request))
                 .co_password(user.get("co_password").toString())
                 .co_newPassword(passwordEncoder.encode(user.get("co_newPassword").toString())).build();
-        return coUserService.updatePassword(coUser);
+        return coUserService.updatePassword(request, coUser);
     }
 
 

--- a/src/main/java/com/codevumc/codev_backend/errorhandler/AutheniticationEntryPointHandler.java
+++ b/src/main/java/com/codevumc/codev_backend/errorhandler/AutheniticationEntryPointHandler.java
@@ -25,6 +25,11 @@ public class AutheniticationEntryPointHandler implements AuthenticationEntryPoin
             setResponse(response, errorCode);
             return;
         }
+        
+        if(exception.equals("PasswordNotFoundException")) {
+            errorCode = ErrorCode.PasswordNotFoundException;
+            setResponse(response, errorCode);
+        }
 
         if(exception.equals("ForbiddenException")) {
             errorCode = ErrorCode.ForbiddenException;

--- a/src/main/java/com/codevumc/codev_backend/errorhandler/ErrorCode.java
+++ b/src/main/java/com/codevumc/codev_backend/errorhandler/ErrorCode.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public enum ErrorCode {
     UsernameOrPasswordNotFoundException (400, "아이디 또는 비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    PasswordNotFoundException (401, "비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
     ForbiddenException(403, "해당 요청에 대한 권한이 없습니다.", HttpStatus.FORBIDDEN),
     UNAUTHORIZEDException (401, "로그인 후 이용가능합니다.", HttpStatus.UNAUTHORIZED),
     ExpiredJwtException(444, "기존 토큰이 만료되었습니다. 해당 토큰을 가지고 /token/refresh 링크로 이동 후 토큰을 재발급 받으세요.", HttpStatus.UNAUTHORIZED),

--- a/src/main/java/com/codevumc/codev_backend/service/co_user/CoUserService.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_user/CoUserService.java
@@ -6,6 +6,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
+import javax.servlet.http.HttpServletRequest;
 import java.io.UnsupportedEncodingException;
 
 public interface CoUserService {
@@ -21,5 +22,5 @@ public interface CoUserService {
 
     CoDevResponse isExistedEmail(String co_email);
 
-    CoDevResponse updatePassword(CoUser coUser);
+    CoDevResponse updatePassword(HttpServletRequest request, CoUser coUser);
 }

--- a/src/main/java/com/codevumc/codev_backend/service/co_user/CoUserServiceImpl.java
+++ b/src/main/java/com/codevumc/codev_backend/service/co_user/CoUserServiceImpl.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service;
 import javax.mail.MessagingException;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
+import javax.servlet.http.HttpServletRequest;
 import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -123,21 +124,24 @@ public class CoUserServiceImpl extends ResponseService implements CoUserService,
     }
 
     @Override
-    public CoDevResponse updatePassword(CoUser coUser) {
+    public CoDevResponse updatePassword(HttpServletRequest request, CoUser coUser) {
         try {
             BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
             Optional<CoUser> coUserDto = this.coUserMapper.findByEmail(coUser.getCo_email());
             if (encoder.matches(coUser.getCo_password(),coUserDto.get().getCo_password())){
                 this.coUserMapper.updatePassword(coUser);
                 return setResponse(200,"message","비밀번호가 변경되었습니다");
-            } else {
-                return setResponse(445,"message","비밀번호가 틀렸습니다");
             }
+            throw new SecurityException();
+        } catch (SecurityException e) {
+            request.setAttribute("exception", "PasswordNotFoundException");
+            throw new AuthenticationCustomException(ErrorCode.PasswordNotFoundException);
         } catch (Exception e) {
             e.printStackTrace();
         }
         return null;
     }
+
 
 
 


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->

### ✨ PR 타이틀 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 --> 
- #244 
### 🗓️ PR 날짜 🗓️
<!-- YYYY/NN/DD -->
- 2023/02/10

### ❓ 변경 사항 ❓
<!-- 내용을 적어주세요 -->
- 비밀번호 변경 에러메세지 수정

### 🧐 구현 방법 🧐
<!-- 내용을 적어주세요 -->
```JAVA
    @Override
    public CoDevResponse updatePassword(HttpServletRequest request, CoUser coUser) {
        try {
            BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
            Optional<CoUser> coUserDto = this.coUserMapper.findByEmail(coUser.getCo_email());
            if (encoder.matches(coUser.getCo_password(),coUserDto.get().getCo_password())){
                this.coUserMapper.updatePassword(coUser);
                return setResponse(200,"message","비밀번호가 변경되었습니다");
            }
            throw new SecurityException();
        } catch (SecurityException e) {
            request.setAttribute("exception", "PasswordNotFoundException");
            throw new AuthenticationCustomException(ErrorCode.PasswordNotFoundException);
        } catch (Exception e) {
            e.printStackTrace();
        }
        return null;
    }
```

### 📸 API 명세서 사진 📸
<!-- 사진 첨부 -->
- 
