### PR TITLE
[Fix/#248] 프로젝트, 스터디 지원자 조회 시 임시저장 여부 반영

### DIFF
--- a/src/main/resources/com/codevumc/codev_backend/mapper/CoProjectMapper.xml
+++ b/src/main/resources/com/codevumc/codev_backend/mapper/CoProjectMapper.xml
@@ -196,6 +196,7 @@
               </when>
               <otherwise>
                   and crp.co_partId = #{co_partId}
+                  and crp.co_temporaryStorage = false
               </otherwise>
           </choose>
         order by crp.createdAt asc;

--- a/src/main/resources/com/codevumc/codev_backend/mapper/CoProjectMapper.xml
+++ b/src/main/resources/com/codevumc/codev_backend/mapper/CoProjectMapper.xml
@@ -216,6 +216,7 @@
                  left join (select crop.co_projectId, crop.co_partId, count(*) as co_recruitCount
                             from CoRecruitOfProject crop
                             where co_projectId = #{co_projectId}
+                            and crop.co_temporaryStorage = false
                             group by crop.co_partId) crop on crop.co_partId = cpop.co_part
         where cpop.co_projectId = #{co_projectId};
     </select>

--- a/src/main/resources/com/codevumc/codev_backend/mapper/CoStudyMapper.xml
+++ b/src/main/resources/com/codevumc/codev_backend/mapper/CoStudyMapper.xml
@@ -223,7 +223,9 @@
                 where cros.co_temporaryStorage = true
             </when>
             <otherwise>
-                where cros.co_studyId = #{co_studyId} and cpos.co_part = #{co_part}
+                where cros.co_studyId = #{co_studyId}
+                    and cpos.co_part = #{co_part}
+                    and cros.co_temporaryStorage = false
             </otherwise>
         </choose>
         order by cros.createdAt asc;

--- a/src/main/resources/com/codevumc/codev_backend/mapper/CoStudyMapper.xml
+++ b/src/main/resources/com/codevumc/codev_backend/mapper/CoStudyMapper.xml
@@ -238,7 +238,8 @@
         from CoPartOfStudy cpos
                  left join (select cros.co_studyId as 'co_studyId', count(*) as 'co_applicantCount'
                             from CoRecruitOfStudy cros
-                            where cros.co_studyId = #{co_studyId}) cros on cros.co_studyId = cpos.co_studyId
+                            where cros.co_studyId = #{co_studyId}
+                              and cros.co_temporaryStorage = false) cros on cros.co_studyId = cpos.co_studyId
         where cpos.co_studyId = #{co_studyId};
     </select>
 


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->

### ✨ PR 타이틀 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 --> 
- #248 
### 🗓️ PR 날짜 🗓️
<!-- YYYY/NN/DD -->
- 2023/2/12

### ❓ 변경 사항 ❓
<!-- 내용을 적어주세요 -->
- temp가 아닌 다른 파트의 지원자 조회 시, 임시저장이 안된 지원자만 조회하도록 쿼리 조건문 추가

### 🧐 구현 방법 🧐
<!-- 내용을 적어주세요 -->
- 스터디, 프로젝트 모두 반영
- temp가 아닌 파트의 지원자 수 카운트 쿼리에 조건문 추가
`and crp.co_temporaryStorage = false`
- temp가 아닌 파트의 지원자 정보 조회 쿼리에 조건문 추가
`and crp.co_temporaryStorage = false`

### 📸 API 명세서 사진 📸
<!-- 사진 첨부 -->
- 스터디, 프로젝트 모두 동일
- 임시저장 없는 경우(임시저장 지원자 수 :0, 백엔드 지원자 수: 2)
<img width="1996" alt="image" src="https://user-images.githubusercontent.com/48800281/218275548-a47a29d2-5877-4366-97c0-3fd2d46c9284.png">

- 한명이 임시저장 된 경우(임시저장 지원자 수: 1, 백엔드 지원자 수: 1)
<img width="1996" alt="image" src="https://user-images.githubusercontent.com/48800281/218275577-30d9f35d-cde4-4a8d-86a5-dc8636e7911d.png">

