### PR TITLE
[Fix/#307] 정보/질문게시판 상세조회 댓글 대댓글 조회시 profileImg null 해결

### DIFF
--- a/src/main/java/com/codevumc/codev_backend/domain/CoCommentOfInfoBoard.java
+++ b/src/main/java/com/codevumc/codev_backend/domain/CoCommentOfInfoBoard.java
@@ -15,6 +15,7 @@ public class CoCommentOfInfoBoard {
     private long co_coib;
     private String co_email;
     private String co_nickname;
+    private String profileImg;
     private long co_infoId;
     private String content;
     private Timestamp createdAt;

--- a/src/main/java/com/codevumc/codev_backend/domain/CoCommentOfQnaBoard.java
+++ b/src/main/java/com/codevumc/codev_backend/domain/CoCommentOfQnaBoard.java
@@ -15,6 +15,7 @@ public class CoCommentOfQnaBoard {
     private long co_coqb;
     private String co_email;
     private String co_nickname;
+    private String profileImg;
     private long co_qnaId;
     private String content;
     private Timestamp createdAt;

--- a/src/main/java/com/codevumc/codev_backend/domain/CoReCommentOfInfoBoard.java
+++ b/src/main/java/com/codevumc/codev_backend/domain/CoReCommentOfInfoBoard.java
@@ -13,6 +13,7 @@ public class CoReCommentOfInfoBoard {
     private long co_rcoib;
     private String co_email;
     private String co_nickname;
+    private String profileImg;
     private long co_coib;
     private String content;
     private Timestamp createdAt;

--- a/src/main/java/com/codevumc/codev_backend/domain/CoReCommentOfQnaBoard.java
+++ b/src/main/java/com/codevumc/codev_backend/domain/CoReCommentOfQnaBoard.java
@@ -13,6 +13,7 @@ public class CoReCommentOfQnaBoard {
     private long co_rcoqb;
     private String co_email;
     private String co_nickname;
+    private String profileImg;
     private long co_coqb;
     private String content;
     private Timestamp createdAt;

--- a/src/main/resources/com/codevumc/codev_backend/mapper/CoInfoBoardMapper.xml
+++ b/src/main/resources/com/codevumc/codev_backend/mapper/CoInfoBoardMapper.xml
@@ -82,6 +82,7 @@
         select  cib.co_infoId                                                               as 'co_infoId',
                 cib.co_email                                                                as 'co_email',
                 cu.co_nickname                                                              as 'co_nickname',
+                cu.profileImg                                                               as 'profileImg',
                 cib.co_title                                                                as 'co_title',
                 cib.content                                                                 as 'content',
                 (select count(co_infoId) from CoLikeOfInfoBoard where co_infoId = #{co_infoId}) as 'co_likeCount',
@@ -164,6 +165,7 @@
                ccoib.co_infoId as 'co_infoId',
                ccoib.co_email as 'co_email',
                cu.co_nickname as 'co_nickname',
+               cu.profileImg as 'profileImg',
                ccoib.content as 'content',
                ccoib.createdAt as 'createdAt'
         from CoCommentOfInfoBoard as ccoib
@@ -176,6 +178,7 @@
                crcoib.co_coib as 'co_coib',
                crcoib.co_email as 'co_email',
                cu.co_nickname as 'co_nickname',
+               cu.profileImg as 'profileImg',
                crcoib.content as 'content',
                crcoib.createdAt as 'createdAt'
         from CoReCommentOfInfoBoard as crcoib
@@ -192,6 +195,7 @@
         <result property="co_infoId" column="CO_INFOID"/>
         <result property="co_email" column="CO_EMAIL"/>
         <result property="co_nickname" column="CO_NICKNAME"/>
+        <result property="profileImg" column="PROFILEIMG"/>
         <result property="content" column="CONTENT"/>
         <result property="createdAt" column="CREATEDAT"/>
         <collection property="coReCommentOfInfoBoardList" column="CO_COIB" javaType="java.util.ArrayList" ofType="CoReCommentOfInfoBoard" select="getReComment"/>

--- a/src/main/resources/com/codevumc/codev_backend/mapper/CoQnaBoardMapper.xml
+++ b/src/main/resources/com/codevumc/codev_backend/mapper/CoQnaBoardMapper.xml
@@ -90,6 +90,7 @@
         select cqb.co_qnaId                                                                as 'co_qnaId',
                cqb.co_email                                                                as 'co_email',
                cu.co_nickname                                                              as 'co_nickname',
+               cu.profileImg                                                               as 'profileImg',
                cqb.co_title                                                                as 'co_title',
                cqb.content                                                                 as 'content',
                (select count(co_qnaId) from CoLikeOfQnaBoard where co_qnaId = #{co_qnaId}) as 'co_likeCount',
@@ -128,6 +129,7 @@
                ccoqb.co_qnaId as 'co_qnaId',
                ccoqb.co_email as 'co_email',
                cu.co_nickname as 'co_nickname',
+               cu.profileImg as 'profileImg',
                ccoqb.content as 'content',
                ccoqb.createdAt as 'createdAt'
         from CoCommentOfQnaBoard as ccoqb
@@ -140,6 +142,7 @@
                crcoqb.co_coqb as 'co_coqb',
                crcoqb.co_email as 'co_email',
                cu.co_nickname as 'co_nickname',
+               cu.profileImg as 'profileImg',
                crcoqb.content as 'content',
                crcoqb.createdAt as 'createdAt'
         from CoReCommentOfQnaBoard as crcoqb
@@ -156,6 +159,7 @@
         <result property="co_qnaId" column="CO_QNAID"/>
         <result property="co_email" column="CO_EMAIL"/>
         <result property="co_nickname" column="CO_NICKNAME"/>
+        <result property="profileImg" column="PROFILEIMG"/>
         <result property="content" column="CONTENT"/>
         <result property="createdAt" column="CREATEDAT"/>
         <collection property="coReCommentOfQnaBoardList" column="CO_COQB" javaType="java.util.ArrayList" ofType="CoReCommentOfQnaBoard" select="getReComment"/>


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->

### ✨ PR 타이틀 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 --> 
- #307 
### 🗓️ PR 날짜 🗓️
<!-- YYYY/NN/DD -->
- 2023/04/10

### ❓ 변경 사항 ❓
<!-- 내용을 적어주세요 -->
- 

### 🧐 구현 방법 🧐
<!-- 내용을 적어주세요 -->
- 

### 📸 API 명세서 사진 📸
<!-- 사진 첨부 -->
- 
